### PR TITLE
Generic payload (not just map[string]...)

### DIFF
--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -59,7 +59,7 @@ func adapterFunc(handler HandlerFunc) http.HandlerFunc {
 			origRequest,
 			nil,
 			map[string]interface{}{},
-			map[string]interface{}{},
+			nil,
 		}
 
 		writer := &responseWriter{

--- a/rest/middleware_test.go
+++ b/rest/middleware_test.go
@@ -41,6 +41,7 @@ func TestWrapMiddlewares(t *testing.T) {
 		nil,
 		nil,
 		map[string]interface{}{},
+		nil,
 	}
 
 	handlerFunc(nil, r)

--- a/rest/request.go
+++ b/rest/request.go
@@ -17,9 +17,10 @@ type Request struct {
 
 	// Environment used by middlewares to communicate.
 	Env map[string]interface{}
-	
-	// Used to unmarshal the incoming JSON request
-	Payload map[string]interface{}
+
+	// Application-specific context for communication between middleware and
+	// handlers
+	Payload interface{}
 }
 
 // PathParam provides a convenient access to the PathParams map.

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -15,6 +15,7 @@ func defaultRequest(method string, urlStr string, body io.Reader, t *testing.T) 
 		origReq,
 		nil,
 		map[string]interface{}{},
+		nil,
 	}
 }
 


### PR DESCRIPTION
I could have used Env["somekey"] instead, but this is at least a slight improvement over what it used to be.
